### PR TITLE
Add specific keyframes handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 -   `fonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Shorthand for setting `inlineFonts`+`preloadFonts`-   values:
     -   `true` to inline critical font-face rules and preload the fonts
     -   `false` to don't inline any font-face rules and don't preload fonts
--   `keyframes` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Which [keyframes strategy](#criticalKeyframes) to use _(default: `critical`)_
+-   `keyframes` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Which [keyframes strategy](#keyframesstrategy) to use _(default: `critical`)_
 -   `compress` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Compress resulting critical CSS _(default: `true`)_
 
 ### PreloadStrategy
@@ -107,7 +107,7 @@ _[JS]_ indicates that a strategy requires JavaScript (falls back to `<noscript>`
 
 Type: (default | `"body"` \| `"media"` \| `"swap"` \| `"js"` \| `"js-lazy"`)
 
-### Critical Keyframes Strategy
+### KeyframesStrategy
 
 The strategy to use when inlining keyframes.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 -   `fonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Shorthand for setting `inlineFonts`+`preloadFonts`-   values:
     -   `true` to inline critical font-face rules and preload the fonts
     -   `false` to don't inline any font-face rules and don't preload fonts
--   `criticalKeyframes` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Which [criticalKeyframes strategy](#criticalKeyframes) to use _(default: `critical`)_
+-   `keyframes` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Which [keyframes strategy](#criticalKeyframes) to use _(default: `critical`)_
 -   `compress` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Compress resulting critical CSS _(default: `true`)_
 
 ### PreloadStrategy
@@ -109,7 +109,7 @@ Type: (default | `"body"` \| `"media"` \| `"swap"` \| `"js"` \| `"js-lazy"`)
 
 ### Critical Keyframes Strategy
 
-The strategy to use when inlining critical keyframes.
+The strategy to use when inlining keyframes.
 
 -   **"critical":** Move stylesheet links to the end of the document and insert preload meta tags in their place.
 -   **"all":** Move all external stylesheet links to the end of the document.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 -   `fonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Shorthand for setting `inlineFonts`+`preloadFonts`-   values:
     -   `true` to inline critical font-face rules and preload the fonts
     -   `false` to don't inline any font-face rules and don't preload fonts
+-   `criticalKeyframes` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Which [criticalKeyframes strategy](#criticalKeyframes) to use _(default: `critical`)_
 -   `compress` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Compress resulting critical CSS _(default: `true`)_
 
 ### PreloadStrategy
@@ -105,6 +106,16 @@ _[JS]_ indicates that a strategy requires JavaScript (falls back to `<noscript>`
 -   **"js-lazy":** Like `"js"`, but the stylesheet is disabled until fully loaded.
 
 Type: (default | `"body"` \| `"media"` \| `"swap"` \| `"js"` \| `"js-lazy"`)
+
+### Critical Keyframes Strategy
+
+The strategy to use when inlining critical keyframes.
+
+-   **"critical":** Move stylesheet links to the end of the document and insert preload meta tags in their place.
+-   **"all":** Move all external stylesheet links to the end of the document.
+-   **"none":** Load stylesheets asynchronously by adding `media="not x"` and removing once loaded. _[JS]_
+
+Type: ('"critical"' | `"all"` \| `"none"`)
 
 ## Similar Libraries
 

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ const PLUGIN_NAME = 'critters-webpack-plugin';
  * - **"js":** Inject an asynchronous CSS loader similar to [LoadCSS](https://github.com/filamentgroup/loadCSS) and use it to load stylesheets. _[JS]_
  * - **"js-lazy":** Like `"js"`, but the stylesheet is disabled until fully loaded.
  * @typedef {(default|'body'|'media'|'swap'|'js'|'js-lazy')} PreloadStrategy
- * @typedef {('critical'|'all'|'none')} CriticalKeyframes
+ * @typedef {('critical'|'all'|'none')} Keyframes
  * @public
  */
 
@@ -51,7 +51,7 @@ const PLUGIN_NAME = 'critters-webpack-plugin';
  *  - values:
  *  - `true` to inline critical font-face rules and preload the fonts
  *  - `false` to don't inline any font-face rules and don't preload fonts
- * @property {String} criticalKeyframes Which {@link CriticalKeyframes inline strategy} to use (default: `critical`)_
+ * @property {String}  keyframes     Which {@link Keyframes inline strategy} to use (default: `critical`)_
  * @property {Boolean} compress     Compress resulting critical CSS _(default: `true`)_
  */
 
@@ -251,7 +251,7 @@ export default class Critters {
     const options = this.options;
     const document = style.ownerDocument;
     const head = document.querySelector('head');
-    const criticalKeyframeMode = options.criticalKeyframes || 'critical'
+    const KeyframesMode = options.keyframes || 'critical'
 
     // basically `.textContent`
     let sheet = style.childNodes.length > 0 && style.childNodes.map(node => node.nodeValue).join('\n');
@@ -297,13 +297,13 @@ export default class Critters {
 
       if (rule.type === 'keyframes') {
         // keeping keyframes when set to 'critical' or 'all'
-        return criticalKeyframeMode !== 'none';
+        return KeyframesMode !== 'none';
       }
       // If there are no remaining rules, remove the whole rule:
       return !rule.rules || rule.rules.length !== 0;
     });
 
-    if (criticalKeyframeMode === 'critical') {
+    if (KeyframesMode === 'critical') {
       walkStyleRules(ast, (rule) => {
         if (rule.type === 'keyframes') {
           return this.isKeyframeUsed(rule, ast);


### PR DESCRIPTION
@barak007 and I played around with this project for a bit (super cool btw!) and came across some funky behavior with keyframes (it would inline all keyframes even when not used).

We've quickly put together an addition that handles keyframes. It could probably be written in a cleaner fashion, and with more edge-cases in mind. Should probably collect all used keyframe names in a first pass, and then in a second pass only check for usage, avoiding the currently existing recursion. 

The process is based on the assumption that there is no other stylesheet consuming the same keyframes.

We've added an option (`keyframes` - `critical | all | none`) for this purpose to the configuration.
