### PR TITLE
Fix exception when child combinator is placed before pseudo-elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -366,7 +366,7 @@ export default class Critters {
         rule.filterSelectors(sel => {
           // Strip pseudo-elements and pseudo-classes, since we only care that their associated elements exist.
           // This means any selector for a pseudo-element or having a pseudo-class will be inlined if the rest of the selector matches.
-          sel = sel.replace(/::?[a-z-]+\s*(\{|$)/gi, '$1').trim();
+          sel = sel.replace(/(>\s*)?::?[a-z-]+\s*(\{|$)/gi, '$2').trim();
           if (!sel) return false;
 
           try {


### PR DESCRIPTION
If only pseudo-elements or pseudo-classes are removed, it will throw error "selector is not a valid selector".

The solution is removing child combinator in this case.

I encountered this exception at first when i ran with the https://github.com/GoogleChromeLabs/squoosh project locally.