### PR TITLE
Ensure an inline stylesheet exists before merging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -212,6 +212,10 @@ export default class Critters {
 
   async mergeStylesheets (document) {
     const styles = [].slice.call(document.querySelectorAll('style'));
+    if (styles.length === 0) {
+      this.logger.warn('Merging inline stylesheets into a single <style> tag skipped, no inline stylesheets to merge');
+      return;
+    }
     const first = styles[0];
     let sheet = first.textContent;
     for (let i = 1; i < styles.length; i++) {


### PR DESCRIPTION
This PR fixes the case when no inline style tags are found to merge yet critters still attempts to merge; This occurs when Critters does not generate an inline style tag or one does not exist, and the option `mergeStylesheets` is true (default). 


```
ERROR in   TypeError: Cannot read property 'textContent' of undefined

  - critters.js:255 Critters.<anonymous>
    [ui]/[critters-webpack-plugin]/dist/critters.js:255:23

  - new Promise

  - critters.js:247 Critters.mergeStylesheets
    [ui]/[critters-webpack-plugin]/dist/critters.js:247:12

  - critters.js:224 Critters.<anonymous>
    [ui]/[critters-webpack-plugin]/dist/critters.js:224:37
```
