### PR TITLE
Fix support for output.publicPath

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -184,6 +184,7 @@ export default class Critters {
    */
   async process (compiler, compilation, html) {
     const outputPath = compiler.options.output.path;
+    const publicPath = compiler.options.output.publicPath;
 
     // Parse the generated HTML in a DOM we can mutate
     const document = createDocument(html);
@@ -192,7 +193,7 @@ export default class Critters {
     if (this.options.external !== false) {
       const externalSheets = [].slice.call(document.querySelectorAll('link[rel="stylesheet"]'));
       await Promise.all(externalSheets.map(
-        link => this.embedLinkedStylesheet(link, compilation, outputPath)
+        link => this.embedLinkedStylesheet(link, compilation, outputPath, publicPath)
       ));
     }
 
@@ -232,7 +233,7 @@ export default class Critters {
   /**
    * Inline the target stylesheet referred to by a <link rel="stylesheet"> (assuming it passes `options.filter`)
    */
-  async embedLinkedStylesheet (link, compilation, outputPath) {
+  async embedLinkedStylesheet (link, compilation, outputPath, publicPath) {
     const href = link.getAttribute('href');
     const media = link.getAttribute('media');
     const document = link.ownerDocument;
@@ -242,8 +243,13 @@ export default class Critters {
     // skip filtered resources, or network resources if no filter is provided
     if (this.urlFilter ? this.urlFilter(href) : href.match(/^(https?:)?\/\//)) return Promise.resolve();
 
-    // path on disk
-    const filename = path.resolve(outputPath, href.replace(/^\//, ''));
+    // path on disk (with output.publicPath removed)
+    let normalizedPath = href.replace(/^\//, '');
+    const pathPrefix = (publicPath || '').replace(/(^\/|\/$)/g, '') + '/';
+    if (normalizedPath.indexOf(pathPrefix) === 0) {
+      normalizedPath = normalizedPath.substring(pathPrefix.length).replace(/^\//, '');
+    }
+    const filename = path.resolve(outputPath, normalizedPath);
 
     // try to find a matching asset by filename in webpack's output (not yet written to disk)
     const relativePath = path.relative(outputPath, filename).replace(/^\.\//, '');

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -208,6 +208,77 @@ footer {
 <link rel=\\"stylesheet\\" href=\\"main.css\\"></body></html>"
 `;
 
+exports[`publicPath should match snapshot 1`] = `
+"<!DOCTYPE html><html><head>
+    <title>External CSS Demo</title>
+  <style>body {
+  padding-left: 11em;
+  font-family: \\"Times New Roman\\", times, serif;
+  color: purple;
+  background-color: #d8da3d;
+}
+
+ul.navbar {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  position: absolute;
+  top: 2em;
+  left: 1em;
+  width: 9em;
+}
+
+h1 {
+  font-family: helvetica, arial, sans-serif;
+}
+
+ul.navbar li {
+  background: white;
+  margin: 0.5em 0;
+  padding: 0.3em;
+  border-right: 1em solid black;
+}
+
+ul.navbar a {
+  text-decoration: none;
+}
+
+a:link {
+  color: blue;
+}
+
+a:visited {
+  color: purple;
+}
+
+footer {
+  margin-top: 1em;
+  padding-top: 1em;
+  border-top: thin dotted;
+}</style><link href=\\"/_public/main.css\\" rel=\\"preload\\" as=\\"style\\"></head>
+  <body>
+    <ul class=\\"navbar\\">
+      <li>
+        <a href=\\"index.html\\">Home page</a>
+      </li>
+      <li>
+        <a href=\\"musings.html\\">Musings</a>
+      </li>
+    </ul>
+    <h1>My first styled page</h1>
+    <p>Welcome to my styled page!</p>
+    <footer>Made 5 April 2004</footer>
+  <script type=\\"text/javascript\\" src=\\"/_public/bundle.js\\"></script>
+
+<link rel=\\"stylesheet\\" href=\\"/_public/main.css\\"></body></html>"
+`;
+
+exports[`publicPath should prune external sheet 1`] = `
+".extra-style {
+  font-size: 200%;
+}"
+`;
+
 exports[`webpack compilation 1`] = `
 "<!DOCTYPE html>
 <html>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,6 +73,10 @@ describe('External CSS', () => {
     output = await compileToHtml('external', configure);
   });
 
+  it('should inline critical styles', () => {
+    expect(output.html).toMatch(/ul\.navbar\s*\{/);
+  });
+
   it('should omit non-critical styles', () => {
     expect(output.html).not.toMatch(/\.extra-style/);
   });
@@ -81,6 +85,46 @@ describe('External CSS', () => {
     const link = output.document.querySelector('link[rel="stylesheet"]');
     expect(link).not.toBeNull();
     expect(link).toHaveProperty('href', 'main.css');
+  });
+
+  it('should match snapshot', () => {
+    expect(output.html).toMatchSnapshot();
+  });
+
+  it('should prune external sheet', async () => {
+    const externalCss = await readFile('fixtures/external/dist/main.css');
+    expect(externalCss).toMatch(/\.extra-style\s*\{/);
+    expect(externalCss).toMatchSnapshot();
+  });
+});
+
+describe('publicPath', () => {
+  let output;
+  beforeAll(async () => {
+    output = await compileToHtml('external', config => {
+      configure(config);
+      config.output.publicPath = '/_public/';
+    });
+  });
+
+  it('should inline critical styles', () => {
+    expect(output.html).toMatch(/ul\.navbar\s*\{/);
+  });
+
+  it('should omit non-critical styles', () => {
+    expect(output.html).not.toMatch(/\.extra-style/);
+  });
+
+  it('should reference from publicPath', () => {
+    const link = output.document.querySelector('link[rel="stylesheet"]');
+    expect(link).not.toBeNull();
+    expect(link).toHaveProperty('href', '/_public/main.css');
+  });
+
+  it('should preload from publicPath', () => {
+    const link = output.document.querySelector('link[rel="preload"]');
+    expect(link).not.toBeNull();
+    expect(link).toHaveProperty('href', '/_public/main.css');
   });
 
   it('should match snapshot', () => {


### PR DESCRIPTION
This corrects asset/file names for reading and writing stylesheets when Webpack's `output.publicPath` setting is used.