### PR TITLE
Preserve :root ruleset

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -394,7 +394,9 @@ export default class Critters {
         rule.filterSelectors(sel => {
           // Strip pseudo-elements and pseudo-classes, since we only care that their associated elements exist.
           // This means any selector for a pseudo-element or having a pseudo-class will be inlined if the rest of the selector matches.
-          sel = sel.replace(/(?:>\s*)?::?[a-z-]+\s*(\{|$)/gi, '$1').trim();
+          if (sel !== ':root') {
+            sel = sel.replace(/(?:>\s*)?::?[a-z-]+\s*(\{|$)/gi, '$1').trim();
+          }
           if (!sel) return false;
 
           try {

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -3,7 +3,11 @@
 exports[`External CSS should match snapshot 1`] = `
 "<!DOCTYPE html><html><head>
     <title>External CSS Demo</title>
-  <style>body {
+  <style>:root {
+  font-size: 10px;
+}
+
+body {
   padding-left: 11em;
   font-family: \\"Times New Roman\\", times, serif;
   color: purple;
@@ -146,7 +150,11 @@ footer {
 exports[`options { async:true } should match snapshot 1`] = `
 "<!DOCTYPE html><html><head>
     <title>External CSS Demo</title>
-  <style>body {
+  <style>:root {
+  font-size: 10px;
+}
+
+body {
   padding-left: 11em;
   font-family: \\"Times New Roman\\", times, serif;
   color: purple;
@@ -211,7 +219,11 @@ footer {
 exports[`publicPath should match snapshot 1`] = `
 "<!DOCTYPE html><html><head>
     <title>External CSS Demo</title>
-  <style>body {
+  <style>:root {
+  font-size: 10px;
+}
+
+body {
   padding-left: 11em;
   font-family: \\"Times New Roman\\", times, serif;
   color: purple;

--- a/test/fixtures/external/style.css
+++ b/test/fixtures/external/style.css
@@ -1,3 +1,6 @@
+:root {
+  font-size: 10px;
+}
 body {
   padding-left: 11em;
   font-family: "Times New Roman", times, serif;


### PR DESCRIPTION
I noticed a simple ruleset like `:root { background: yellow }` wasn't present in the inlined CSS.

This appears to be a bug, rather than deliberate behaviour.

Merging this PR would probably address #32 as a side-effect.