### PR TITLE
adding includeMatchingStylesheets option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ All optional. Pass them to `new Critters({ ... })`.
 -   `pruneSource` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Remove inlined rules from the external stylesheet _(default: `true`)_
 -   `mergeStylesheets` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Merged inlined stylesheets into a
 single <style> tag _(default: `true`)_
--   `includeMatchingStylesheets` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Glob for matching other stylesheets which should be used to evaluate critical CSS _(default: '')_
+-   `additionalStylesheets` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Glob for matching other stylesheets which should be used to evaluate critical CSS _(default: '')_
 -   `preload` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Which [preload strategy](#preloadstrategy) to use
 -   `noscriptFallback` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Add `<noscript>` fallback to JS-based strategies
 -   `inlineFonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Inline critical font-face rules _(default: `false`)_

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ All optional. Pass them to `new Critters({ ... })`.
 -   `pruneSource` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Remove inlined rules from the external stylesheet _(default: `true`)_
 -   `mergeStylesheets` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Merged inlined stylesheets into a
 single <style> tag _(default: `true`)_
--   `additionalStylesheets` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Glob for matching other stylesheets which should be used to evaluate critical CSS _(default: '')_
+-   `additionalStylesheets` **[String[]](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Glob for matching other stylesheets which should be used to evaluate critical CSS _(default: '')_
 -   `preload` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Which [preload strategy](#preloadstrategy) to use
 -   `noscriptFallback` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Add `<noscript>` fallback to JS-based strategies
 -   `inlineFonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Inline critical font-face rules _(default: `false`)_

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ All optional. Pass them to `new Critters({ ... })`.
 
 **Parameters**
 
--   `options`  
+-   `options`
 
 **Properties**
 
@@ -88,7 +88,9 @@ All optional. Pass them to `new Critters({ ... })`.
 -   `inlineThreshold` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Inline external stylesheets smaller than a given size _(default: `0`)_
 -   `minimumExternalSize` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** If the non-critical external stylesheet would be below this size, just inline it _(default: `0`)_
 -   `pruneSource` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Remove inlined rules from the external stylesheet _(default: `true`)_
--   `mergeStylesheets` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Merged inlined stylesheets into a single <style> tag _(default: `true`)_
+-   `mergeStylesheets` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Merged inlined stylesheets into a
+single <style> tag _(default: `true`)_
+-   `includeMatchingStylesheets` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Glob for matching other stylesheets which should be used to evaluate critical CSS _(default: '')_
 -   `preload` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Which [preload strategy](#preloadstrategy) to use
 -   `noscriptFallback` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Add `<noscript>` fallback to JS-based strategies
 -   `inlineFonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Inline critical font-face rules _(default: `false`)_

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "css": "^2.2.1",
     "cssnano": "^4.1.7",
     "jsdom": "^12.0.0",
+    "minimatch": "^3.0.4",
     "parse5": "^4.0.0",
     "postcss": "^7.0.5",
     "pretty-bytes": "^4.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ const PLUGIN_NAME = 'critters-webpack-plugin';
  * @property {Number} minimumExternalSize If the non-critical external stylesheet would be below this size, just inline it _(default: `0`)_
  * @property {Boolean} pruneSource  Remove inlined rules from the external stylesheet _(default: `true`)_
  * @property {Boolean} mergeStylesheets Merged inlined stylesheets into a single <style> tag _(default: `true`)_
- * @property {String} additionalStylesheets Glob for matching other stylesheets to be used while looking for critical CSS _(default: ``)_.
+ * @property {String[]} additionalStylesheets Glob for matching other stylesheets to be used while looking for critical CSS _(default: ``)_.
  * @property {String} preload       Which {@link PreloadStrategy preload strategy} to use
  * @property {Boolean} noscriptFallback Add `<noscript>` fallback to JS-based strategies
  * @property {Boolean} inlineFonts  Inline critical font-face rules _(default: `false`)_
@@ -192,11 +192,18 @@ export default class Critters {
     const document = createDocument(html);
 
     if (this.options.additionalStylesheets) {
-      const webpackCssAssets = Object.keys(compilation.assets).filter(file => minimatch(file, this.options.additionalStylesheets));
-      webpackCssAssets.map(asset => {
-        const tag = document.createElement('style');
-        tag.innerHTML = compilation.assets[asset].source();
-        document.head.appendChild(tag);
+      const styleSheetsIncluded = [];
+      (this.options.additionalStylesheets || []).forEach(cssFile => {
+        if (styleSheetsIncluded.includes(cssFile)) {
+          return;
+        }
+        styleSheetsIncluded.push(cssFile);
+        const webpackCssAssets = Object.keys(compilation.assets).filter(file => minimatch(file, cssFile));
+        webpackCssAssets.map(asset => {
+          const tag = document.createElement('style');
+          tag.innerHTML = compilation.assets[asset].source();
+          document.head.appendChild(tag);
+        });
       });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ const PLUGIN_NAME = 'critters-webpack-plugin';
  * @property {Number} minimumExternalSize If the non-critical external stylesheet would be below this size, just inline it _(default: `0`)_
  * @property {Boolean} pruneSource  Remove inlined rules from the external stylesheet _(default: `true`)_
  * @property {Boolean} mergeStylesheets Merged inlined stylesheets into a single <style> tag _(default: `true`)_
- * @property {String} includeMatchingStylesheets Glob for matching other stylesheets to be used while looking for critical CSS _(default: ``)_.
+ * @property {String} additionalStylesheets Glob for matching other stylesheets to be used while looking for critical CSS _(default: ``)_.
  * @property {String} preload       Which {@link PreloadStrategy preload strategy} to use
  * @property {Boolean} noscriptFallback Add `<noscript>` fallback to JS-based strategies
  * @property {Boolean} inlineFonts  Inline critical font-face rules _(default: `false`)_
@@ -191,8 +191,8 @@ export default class Critters {
     // Parse the generated HTML in a DOM we can mutate
     const document = createDocument(html);
 
-    if (this.options.includeMatchingStylesheets) {
-      const webpackCssAssets = Object.keys(compilation.assets).filter(file => minimatch(file, this.options.includeMatchingStylesheets));
+    if (this.options.additionalStylesheets) {
+      const webpackCssAssets = Object.keys(compilation.assets).filter(file => minimatch(file, this.options.additionalStylesheets));
       webpackCssAssets.map(asset => {
         const tag = document.createElement('style');
         tag.innerHTML = compilation.assets[asset].source();


### PR DESCRIPTION
- Use this option to specify GLOB of other files you want to be used while evaluating critical CSS.
e.g.
``` js
     if (config['inline-css']) {
		prodConfig.plugins.push(new CrittersPlugin({
			pruneSource: false,
			logLevel: 'silent',
			includeMatchingStylesheets: '*.css'
		}));
    }
```
// @developit 