### PR TITLE
Fix minor typo in warning log

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -527,7 +527,7 @@ export default class Critters {
         afterText = `, reducing non-inlined size ${percent | 0}% to ${prettyBytes(sheetInverse.length)}`;
         style.$$assets[style.$$assetName] = new sources.LineToLineMappedSource(sheetInverse, style.$$assetName, before);
       } else {
-        this.logger.warn('pruneSource is enabaled, but a style (' + name + ') has no corresponding Webpack asset.');
+        this.logger.warn('pruneSource is enabled, but a style (' + name + ') has no corresponding Webpack asset.');
       }
     }
 


### PR DESCRIPTION
Ran into this warning log while integrating Critters into a project, and noticed the following typo:

![](https://www.dl.dropboxusercontent.com/s/kcrx9pva75hywjq/Screenshot%202020-01-02%2021.05.56.png)