### PR TITLE
fix: use css-nano lite preset when compressing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -214,7 +214,7 @@ export default class Critters {
     }
     if (!this.options.ssrMode && this.options.compress !== false) {
       const before = sheet;
-      const processor = postcss([cssnano()]);
+      const processor = postcss([cssnano({ preset: 'lite' })]);
       const result = await processor.process(before, { from: undefined });
       // @todo sourcemap support (elsewhere first)
       sheet = result.css;


### PR DESCRIPTION
In many cases CSS will be optimised prior of running Critters. 

Re-running css-nano will the default preset might cause issue especially when 3rd parties have disabled certain optimization due to bugs in CSS Nano. Example, in the Angular CLI we disable the `svgo` and `calc` optimizations https://cs.opensource.google/angular/angular-cli/+/master:packages/angular_devkit/build_angular/src/webpack/plugins/optimize-css-webpack-plugin.ts;l=100-105?q=packages%2Fangular_devkit%2Fbuild_angular%2Fsrc%2Fwebpack%2Fplugins%2Foptimize-css-webpack-plugin.ts&ss=angular%2Fangular-cli 

The `lite` present will only remove comments, empty rules and normalize whitespace. see: https://cssnano.co/docs/optimisations which should sufice.