### PR TITLE
fix: handle pseudo-class in middle of selector

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -460,7 +460,7 @@ export default class Critters {
             // Strip pseudo-elements and pseudo-classes, since we only care that their associated elements exist.
             // This means any selector for a pseudo-element or having a pseudo-class will be inlined if the rest of the selector matches.
             if (sel !== ':root') {
-              sel = sel.replace(/(::?[a-z-]+(\(.+?\))?\s*)/gi, ' ').trim();
+              sel = sel.replace(/(?<!\\)::?[a-z-]+(?![a-z-(])/gi, '').replace(/::?not\(\s*\)/g, '').trim();
             }
             if (!sel) return false;
 

--- a/src/index.js
+++ b/src/index.js
@@ -460,7 +460,7 @@ export default class Critters {
             // Strip pseudo-elements and pseudo-classes, since we only care that their associated elements exist.
             // This means any selector for a pseudo-element or having a pseudo-class will be inlined if the rest of the selector matches.
             if (sel !== ':root') {
-              sel = sel.replace(/(?:>\s*)?::?[a-z-]+\s*(\{|$)/gi, '$1').trim();
+              sel = sel.replace(/(::?[a-z-]+(\(.+?\))?\s*)/gi, ' ').trim();
             }
             if (!sel) return false;
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -120,6 +120,14 @@ ul.navbar a {
   text-decoration: none;
 }
 
+ul.navbar:not(.hidden) li:hover a {
+  color: black;
+}
+
+ul.navbar li:hover a {
+  color: red;
+}
+
 a:link {
   color: blue;
 }
@@ -336,12 +344,19 @@ exports[`webpack compilation 1`] = `
       ul.navbar a {
         text-decoration: none;
       }
+      ul.navbar:not(.hidden) li:hover a {
+        color: black;
+      }
+      ul.navbar li:hover a {
+        color: red;
+      }
       a:link {
         color: blue;
       }
       a:visited {
         color: purple;
       }
+
       footer {
         margin-top: 1em;
         padding-top: 1em;
@@ -349,6 +364,9 @@ exports[`webpack compilation 1`] = `
       }
       .extra-style {
         font-size: 200%;
+      }
+      .hidden {
+        visibility: hidden;
       }
     </style>
   </head>

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -124,6 +124,10 @@ ul.navbar:not(.hidden) li:hover a {
   color: black;
 }
 
+ul.navbar:not(:hover) li:hover a {
+  color: black;
+}
+
 ul.navbar li:hover a {
   color: red;
 }
@@ -140,10 +144,14 @@ footer {
   margin-top: 1em;
   padding-top: 1em;
   border-top: thin dotted;
+}
+
+.clazz\\\\:colon {
+  color: green;
 }</style>
   </head>
   <body>
-    <ul class=\\"navbar\\">
+    <ul class=\\"navbar clazz:colon\\">
       <li>
         <a href=\\"index.html\\">Home page</a>
       </li>
@@ -347,6 +355,9 @@ exports[`webpack compilation 1`] = `
       ul.navbar:not(.hidden) li:hover a {
         color: black;
       }
+      ul.navbar:not(:hover) li:hover a {
+        color: black;
+      }
       ul.navbar li:hover a {
         color: red;
       }
@@ -368,10 +379,14 @@ exports[`webpack compilation 1`] = `
       .hidden {
         visibility: hidden;
       }
+
+      .clazz\\\\:colon {
+        color: green;
+      }
     </style>
   </head>
   <body>
-    <ul class=\\"navbar\\">
+    <ul class=\\"navbar clazz:colon\\">
       <li>
         <a href=\\"index.html\\">Home page</a>
       </li>

--- a/test/__snapshots__/standalone.test.js.snap
+++ b/test/__snapshots__/standalone.test.js.snap
@@ -60,6 +60,10 @@ ul.navbar:not(.hidden) li:hover a {
   color: black;
 }
 
+ul.navbar:not(:hover) li:hover a {
+  color: black;
+}
+
 ul.navbar li:hover a {
   color: red;
 }
@@ -76,10 +80,14 @@ footer {
   margin-top: 1em;
   padding-top: 1em;
   border-top: thin dotted;
+}
+
+.clazz\\\\:colon {
+  color: green;
 }</style>
   </head>
   <body>
-    <ul class=\\"navbar\\">
+    <ul class=\\"navbar clazz:colon\\">
       <li>
         <a href=\\"index.html\\">Home page</a>
       </li>

--- a/test/__snapshots__/standalone.test.js.snap
+++ b/test/__snapshots__/standalone.test.js.snap
@@ -56,6 +56,14 @@ ul.navbar a {
   text-decoration: none;
 }
 
+ul.navbar:not(.hidden) li:hover a {
+  color: black;
+}
+
+ul.navbar li:hover a {
+  color: red;
+}
+
 a:link {
   color: blue;
 }

--- a/test/fixtures/basic/index.html
+++ b/test/fixtures/basic/index.html
@@ -33,6 +33,9 @@
       ul.navbar:not(.hidden) li:hover a {
         color: black;
       }
+      ul.navbar:not(:hover) li:hover a {
+        color: black;
+      }
       ul.navbar li:hover a {
         color: red;
       }
@@ -54,10 +57,14 @@
       .hidden {
         visibility: hidden;
       }
+
+      .clazz\:colon {
+        color: green;
+      }
     </style>
   </head>
   <body>
-    <ul class="navbar">
+    <ul class="navbar clazz:colon">
       <li>
         <a href="index.html">Home page</a>
       </li>

--- a/test/fixtures/basic/index.html
+++ b/test/fixtures/basic/index.html
@@ -30,12 +30,19 @@
       ul.navbar a {
         text-decoration: none;
       }
+      ul.navbar:not(.hidden) li:hover a {
+        color: black;
+      }
+      ul.navbar li:hover a {
+        color: red;
+      }
       a:link {
         color: blue;
       }
       a:visited {
         color: purple;
       }
+
       footer {
         margin-top: 1em;
         padding-top: 1em;
@@ -43,6 +50,9 @@
       }
       .extra-style {
         font-size: 200%;
+      }
+      .hidden {
+        visibility: hidden;
       }
     </style>
   </head>


### PR DESCRIPTION
**fix: handle pseudo-class in middle of selector**

At the moment critters doesn't correctly handle pseudo-class in the middle of the selector string and pseudo-class which take a value such as `:not`

Example
```
.mat-slider:hover .mat-slider-track-background
.mat-slider-min-value:not(.mat-slider-thumb-label-showing):hover.mat-slider-disabled .mat-slider-thumb
```

More context about CSS pseudo-classes can be found https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes

Closes #51

**fix: handle classes with colons**

Class names can have `:` if they are escapped. Example: `.flex\:box`