### PR TITLE
fix: improve type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       "text"
     ],
     "collectCoverageFrom": [
-      "src/**/*"
+      "src/**/*.js"
     ],
     "watchPathIgnorePatterns": [
       "node_modules",
@@ -72,7 +72,8 @@
     "jest": "^26.3.0",
     "microbundle": "^0.12.3",
     "mini-css-extract-plugin": "^0.10.0",
-    "webpack": "^4.6.0"
+    "webpack": "^4.6.0",
+    "webpack-log": "^3.0.2"
   },
   "dependencies": {
     "chalk": "^4.1.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,7 +15,7 @@
  */
 
 declare module 'critters' {
-  interface Options {
+  export interface Options {
     path?: string;
     publicPath?: string;
     external?: boolean;
@@ -24,16 +24,24 @@ declare module 'critters' {
     pruneSource?: boolean;
     mergeStylesheets?: boolean;
     additionalStylesheets?: string[];
-    preload?: string;
+    preload?: 'body' | 'media' | 'swap' | 'js' | 'js-lazy';
     noscriptFallback?: boolean;
     inlineFonts?: boolean;
     preloadFonts?: boolean;
     fonts?: boolean;
     keyframes?: string;
     compress?: boolean;
-    logLevel?: string;
-    ssrMode?: boolean;
+    logLevel?: 'info' | 'warn' | 'error' | 'trace' | 'debug' | 'silent';
     reduceInlineStyles?: boolean;
+    logger?: Logger;
+  }
+
+  export interface Logger {
+    trace?: (message: string) => void;
+    debug?: (message: string) => void;
+    info?: (message: string) => void;
+    warn?: (message: string) => void;
+    error?: (message: string) => void;
   }
 
   class Critters {

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,17 @@ import { createLogger } from './util';
  */
 
 /**
+ * Custom logger interface:
+ * @typedef {object} Logger
+ * @public
+ * @property {function(String)} trace - Prints a trace message
+ * @property {function(String)} debug - Prints a debug message
+ * @property {function(String)} info - Prints an information message
+ * @property {function(String)} warn - Prints a warning message
+ * @property {function(String)} error - Prints an error message
+ */
+
+/**
  * All optional. Pass them to `new Critters({ ... })`.
  * @public
  * @typedef Options
@@ -94,7 +105,7 @@ import { createLogger } from './util';
  *  - `"none"` remove all keyframes rules
  * @property {Boolean} compress     Compress resulting critical CSS _(default: `true`)_
  * @property {String} logLevel      Controls {@link LogLevel log level} of the plugin _(default: `"info"`)_
- * @property {Boolean} ssrMode      Optimizes for SSR _(default: `false`)_
+ * @property {object} logger        Provide a custom logger interface {@link Logger logger}
  */
 
 export default class Critters {
@@ -108,7 +119,6 @@ export default class Critters {
         reduceInlineStyles: true,
         pruneSource: false,
         additionalStylesheets: [],
-        ssrMode: false
       },
       options || {}
     );


### PR DESCRIPTION
With this change we improve TypeScript  type definition by adding the `logger` interface and type the `logLevel`

Exposing the logger is important so external users can implement their own logging handling.

Closes #66