### PR TITLE
shouldInlineFonts if fonts or inlineFonts = true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -464,7 +464,7 @@ export default class Critters {
     }
 
     const shouldPreloadFonts = options.fonts === true || options.preloadFonts === true;
-    const shouldInlineFonts = options.fonts !== false && options.inlineFonts === true;
+    const shouldInlineFonts = options.fonts === true || options.inlineFonts === true;
 
     const preloadedFonts = [];
     // Second pass, using data picked up from the first


### PR DESCRIPTION
## Description of changes

This change updates `shouldInlineFonts` to evaluate as described in the README: true if either the `fonts` or `inlineFonts` option is set to true. At the moment, both `fonts` and `inlineFonts` would need to be set to true for the whole statement to be truthy.

-   `inlineFonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Inline critical font-face rules _(default: `false`)_
-   `preloadFonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Preloads critical fonts _(default: `true`)_
-   `fonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Shorthand for setting `inlineFonts`+`preloadFonts`-   Values:
    -   `true` to inline critical font-face rules and preload the fonts
    -   `false` to don't inline any font-face rules and don't preload fonts

@developit 