### PR TITLE
fix: skip processing of HTTP remote stylesheets

### DIFF
--- a/packages/critters/src/index.js
+++ b/packages/critters/src/index.js
@@ -244,7 +244,7 @@ export default class Critters {
     }
 
     // Ignore remote stylesheets
-    if (/^https:\/\//.test(normalizedPath) || href.startsWith('//')) {
+    if (/^https?:\/\//.test(normalizedPath) || href.startsWith('//')) {
       return undefined;
     }
 


### PR DESCRIPTION
In #75 we introduced skipping processing of remote stylesheets however during a rebase a commit that changed the RegExp to handle http protocols (https://github.com/GoogleChromeLabs/critters/commit/dd3f1197144cac737a5a99ed80a37b2a471aa2c6) has been lost.

This change fixes the RegExp to match against `http://` protocols.