### PR TITLE
fix: Adding in missing getter for `document.head`

### DIFF
--- a/packages/critters-webpack-plugin/test/__snapshots__/index.test.js.snap
+++ b/packages/critters-webpack-plugin/test/__snapshots__/index.test.js.snap
@@ -161,6 +161,39 @@ exports[`Inline <style> pruning should remove unused rules 1`] = `
 </body></html>"
 `;
 
+exports[`options { additionalStylesheets:["*.css"] } should match snapshot 1`] = `
+"<!DOCTYPE html><html><head>
+    <title>Additional Stylesheet CSS Demo</title>
+  <style>html {
+  padding: 0px;
+}
+
+html {
+  padding: 0px;
+}
+
+.additional-style {
+  font-size: 200%;
+}
+
+</style><link href=\\"main.css\\" rel=\\"preload\\" as=\\"style\\"></head>
+  <body>
+    <ul class=\\"navbar\\">
+      <li>
+        <a href=\\"index.html\\">Home page</a>
+      </li>
+      <li>
+        <a href=\\"musings.html\\">Musings</a>
+      </li>
+    </ul>
+    <h1 class=\\"additional-style\\">My first styled page</h1>
+    <p>Welcome to my styled page!</p>
+    <footer>Made 5 April 2004</footer>
+  <script src=\\"bundle.js\\"></script>
+
+<link rel=\\"stylesheet\\" href=\\"main.css\\"></body></html>"
+`;
+
 exports[`options { async:true } should match snapshot 1`] = `
 "<!DOCTYPE html><html><head>
     <title>External CSS Demo</title>

--- a/packages/critters-webpack-plugin/test/fixtures/additionalStylesheets/additional.css
+++ b/packages/critters-webpack-plugin/test/fixtures/additionalStylesheets/additional.css
@@ -1,0 +1,3 @@
+.additional-style {
+  font-size: 200%;
+}

--- a/packages/critters-webpack-plugin/test/fixtures/additionalStylesheets/chunk.js
+++ b/packages/critters-webpack-plugin/test/fixtures/additionalStylesheets/chunk.js
@@ -1,0 +1,1 @@
+import './additional.css';

--- a/packages/critters-webpack-plugin/test/fixtures/additionalStylesheets/index.html
+++ b/packages/critters-webpack-plugin/test/fixtures/additionalStylesheets/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Additional Stylesheet CSS Demo</title>
+  </head>
+  <body>
+    <ul class="navbar">
+      <li>
+        <a href="index.html">Home page</a>
+      </li>
+      <li>
+        <a href="musings.html">Musings</a>
+      </li>
+    </ul>
+    <h1 class="additional-style">My first styled page</h1>
+    <p>Welcome to my styled page!</p>
+    <footer>Made 5 April 2004</footer>
+  </body>
+</html>

--- a/packages/critters-webpack-plugin/test/fixtures/additionalStylesheets/index.js
+++ b/packages/critters-webpack-plugin/test/fixtures/additionalStylesheets/index.js
@@ -1,0 +1,5 @@
+import './style.css';
+
+document.body.appendChild(document.createTextNode('this counts as SSR'));
+
+import('./chunk.js').then();

--- a/packages/critters-webpack-plugin/test/fixtures/additionalStylesheets/style.css
+++ b/packages/critters-webpack-plugin/test/fixtures/additionalStylesheets/style.css
@@ -1,0 +1,3 @@
+html {
+  padding: 0px;
+}

--- a/packages/critters-webpack-plugin/test/index.test.js
+++ b/packages/critters-webpack-plugin/test/index.test.js
@@ -137,6 +137,23 @@ describe('publicPath', () => {
 });
 
 describe('options', () => {
+  describe('{ additionalStylesheets:["*.css"] }', () => {
+    let output;
+    beforeAll(async () => {
+      output = await compileToHtml('additionalStylesheets', configure, {
+        additionalStylesheets: ['*.css'],
+      });
+    });
+
+    it('should include additional styles', () => {
+      expect(output.html).toMatch(/\.additional-style/);
+    });
+
+    it('should match snapshot', () => {
+      expect(output.html).toMatchSnapshot();
+    });
+  });
+
   describe('{ async:true }', () => {
     let output;
     beforeAll(async () => {

--- a/packages/critters/src/dom.js
+++ b/packages/critters/src/dom.js
@@ -176,6 +176,12 @@ const DocumentExtensions = {
     }
   },
 
+  head: {
+    get() {
+      return this.querySelector('head');
+    }
+  },
+
   body: {
     get() {
       return this.querySelector('body');

--- a/packages/critters/src/index.js
+++ b/packages/critters/src/index.js
@@ -440,7 +440,6 @@ export default class Critters {
     const name = style.$$name ? style.$$name.replace(/^\//, '') : 'inline CSS';
     const options = this.options;
     // const document = style.ownerDocument;
-    const head = document.querySelector('head');
     let keyframesMode = options.keyframes || 'critical';
     // we also accept a boolean value for options.keyframes
     if (keyframesMode === true) keyframesMode = 'all';
@@ -577,7 +576,7 @@ export default class Critters {
           preload.setAttribute('as', 'font');
           preload.setAttribute('crossorigin', 'anonymous');
           preload.setAttribute('href', src.trim());
-          head.appendChild(preload);
+          document.head.appendChild(preload);
         }
 
         // if we're missing info, if the font is unused, or if critical font inlining is disabled, remove the rule:


### PR DESCRIPTION
Closes #69 

Simply missing a getter for `head`. 

Full stack trace of the error that this fixes. The one in the linked issue is fairly outdated and the error position is no longer correct:

```
TypeError: Cannot read property 'appendChild' of undefined
    at ../../node_modules/critters-webpack-plugin/dist/critters-webpack-plugin.js:199:23
        at Array.map (<anonymous>)
    at ../../node_modules/critters-webpack-plugin/dist/critters-webpack-plugin.js:195:24
        at Array.forEach (<anonymous>)
    at CrittersWebpackPlugin.embedAdditionalStylesheet (../../node_modules/critters-webpack-plugin/dist/critters-webpack-plugin.js:188:48)
    at CrittersWebpackPlugin.process (../../node_modules/critters/dist/critters.js:633:12)
    at handleHtmlPluginData (../../node_modules/critters-webpack-plugin/dist/critters-webpack-plugin.js:85:14)
    at eval (eval at create (../../node_modules/tapable/lib/HookCodeFactory.js:74:10), <anonymous>:13:1)
    at AsyncSeriesWaterfallHook.eval [as promise] (eval at create (../../node_modules/tapable/lib/HookCodeFactory.js:74:10), <anonymous>:2:8)
    at AsyncSeriesWaterfallHook.lazyCompileHook (../../node_modules/tapable/lib/Hook.js:154:20)
    at ../../node_modules/html-webpack-plugin/index.js:267:70
```

Adds a couple tests to ensure `additionalStylesheets` works.