### PR TITLE
fix: add missing peer dependency `html-webpack-plugin`

### DIFF
--- a/packages/critters-webpack-plugin/package.json
+++ b/packages/critters-webpack-plugin/package.json
@@ -58,5 +58,13 @@
     "minimatch": "^3.0.4",
     "webpack-log": "^3.0.1",
     "webpack-sources": "^1.3.0"
+  },
+  "peerDependencies": {
+    "html-webpack-plugin": "^4.5.2"
+  },
+  "peerDependenciesMeta": {
+    "html-webpack-plugin": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`critters-webpack-plugin` tries to require `html-webpack-plugin` (https://github.com/GoogleChromeLabs/critters/blob/5e32531caf7540842ff9af99e9449975bf0ad399/packages/critters-webpack-plugin/src/index.js#L71-L75) but doesn't declare it as a dependency which means under strict dependency environments or if hoisting isn't in its favour it wont get access to it.
https://yarnpkg.com/advanced/rulebook/#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies

Ref https://github.com/preactjs/preact-cli/pull/1608#issuecomment-988417698 (cc @rschristian)

**How did you fix it?**

Based on how `critters-webpack-plugin` is trying to use `html-webpack-plugin` I added it as an optional peer dependency.