### PR TITLE
fix: scss code using keyframes should successfully transform

### DIFF
--- a/packages/critters/src/css.js
+++ b/packages/critters/src/css.js
@@ -157,7 +157,8 @@ function hasNestedRules(rule) {
     rule.nodes &&
     rule.nodes.length &&
     rule.nodes.some((n) => n.type === 'rule' || n.type === 'atrule') &&
-    rule.name !== 'keyframes'
+    rule.name !== 'keyframes' &&
+    rule.name !== '-webkit-keyframes'
   );
 }
 


### PR DESCRIPTION
Applies the suggested fix in #86. Should fix a lot of packages that are dependent on tailwind or windicss animations (like the Vitesse starter template https://github.com/antfu/vitesse, https://github.com/antfu/vite-ssg/issues/158).