### PR TITLE
refactor: use picocolors

### DIFF
--- a/packages/critters/package.json
+++ b/packages/critters/package.json
@@ -46,10 +46,10 @@
     "prepare": "npm run -s build"
   },
   "dependencies": {
-    "chalk": "^4.1.0",
     "css-select": "^4.2.0",
     "parse5": "^6.0.1",
     "parse5-htmlparser2-tree-adapter": "^6.0.1",
+    "picocolors": "^1.0.0",
     "postcss": "^8.3.7",
     "pretty-bytes": "^5.3.0"
   },

--- a/packages/critters/src/index.js
+++ b/packages/critters/src/index.js
@@ -27,6 +27,7 @@ import {
   applyMarkedSelectors
 } from './css';
 import { createLogger } from './util';
+import picocolors from 'picocolors';
 
 /**
  * The mechanism to use for lazy-loading stylesheets.
@@ -271,7 +272,7 @@ export default class Critters {
       const href = style.$$name;
       style.$$reduce = false;
       this.logger.info(
-        `\u001b[32mInlined all of ${href} (${sheet.length} was below the threshold of ${this.options.inlineThreshold})\u001b[39m`
+        picocolors.green(`Inlined all of ${href} (${sheet.length} was below the threshold of ${this.options.inlineThreshold})`)
       );
       link.remove();
       return true;
@@ -416,7 +417,7 @@ export default class Critters {
     const name = style.$$name;
     if (minSize && sheetInverse.length < minSize) {
       this.logger.info(
-        `\u001b[32mInlined all of ${name} (non-critical external stylesheet would have been ${sheetInverse.length}b, which was below the threshold of ${minSize})\u001b[39m`
+        picocolors.green(`Inlined all of ${name} (non-critical external stylesheet would have been ${sheetInverse.length}b, which was below the threshold of ${minSize})`)
       );
       style.textContent = before;
       // remove any associated external resources/loaders:
@@ -630,7 +631,8 @@ export default class Critters {
     // output stats
     const percent = ((sheet.length / before.length) * 100) | 0;
     this.logger.info(
-      '\u001b[32mInlined ' +
+      picocolors.green(
+        'Inlined ' +
         prettyBytes(sheet.length) +
         ' (' +
         percent +
@@ -639,7 +641,8 @@ export default class Critters {
         ') of ' +
         name +
         afterText +
-        '.\u001b[39m'
+        '.'
+      )
     );
   }
 }

--- a/packages/critters/src/util.js
+++ b/packages/critters/src/util.js
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import picocolors from 'picocolors';
 
 const LOG_LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'silent'];
 
@@ -12,15 +12,15 @@ export const defaultLogger = {
   },
 
   warn(msg) {
-    console.warn(chalk.yellow(msg));
+    console.warn(picocolors.yellow(msg));
   },
 
   error(msg) {
-    console.error(chalk.bold.red(msg));
+    console.error(picocolors.bold(picocolors.red(msg)));
   },
 
   info(msg) {
-    console.info(chalk.bold.blue(msg));
+    console.info(picocolors.bold(picocolors.blue(msg)));
   },
 
   silent() {}


### PR DESCRIPTION
Replace `chalk` and inline ASCII with [`picocolors`](https://www.npmjs.com/package/picocolors), a tty color library used by postcss, autoprefixer, svgo, and so on.