### PR TITLE
feat: new preload strategy swap-low

### DIFF
--- a/packages/critters/README.md
+++ b/packages/critters/README.md
@@ -154,6 +154,7 @@ Note: <kbd>JS</kbd> indicates a strategy requiring JavaScript (falls back to `<n
 *   **"media":** Load stylesheets asynchronously by adding `media="not x"` and removing once loaded. <kbd>JS</kbd>
 *   **"swap":** Convert stylesheet links to preloads that swap to `rel="stylesheet"` once loaded ([details](https://www.filamentgroup.com/lab/load-css-simpler/#the-code)). <kbd>JS</kbd>
 *   **"swap-high":** Use `<link rel="alternate stylesheet preload">` and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-high.html)). <kbd>JS</kbd>
+*   **"swap-low":** Use `<link rel="alternate stylesheet">` (no `preload` in `rel` here!) and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-low.html)). It ensures lowest priority compare to `swap-high`. <kbd>JS</kbd>
 *   **"js":** Inject an asynchronous CSS loader similar to [LoadCSS](https://github.com/filamentgroup/loadCSS) and use it to load stylesheets. <kbd>JS</kbd>
 *   **"js-lazy":** Like `"js"`, but the stylesheet is disabled until fully loaded.
 *   **false:** Disables adding preload tags.

--- a/packages/critters/src/index.d.ts
+++ b/packages/critters/src/index.d.ts
@@ -47,7 +47,7 @@ export interface Options {
   pruneSource?: boolean;
   mergeStylesheets?: boolean;
   additionalStylesheets?: string[];
-  preload?: 'body' | 'media' | 'swap' | 'js' | 'js-lazy';
+  preload?: 'body' | 'media' | 'swap' | 'swap-high' | 'swap-low' | 'js' | 'js-lazy';
   noscriptFallback?: boolean;
   inlineFonts?: boolean;
   preloadFonts?: boolean;

--- a/packages/critters/src/index.js
+++ b/packages/critters/src/index.js
@@ -38,10 +38,11 @@ import { createLogger } from './util';
  * - **"media":** Load stylesheets asynchronously by adding `media="not x"` and removing once loaded. <kbd>JS</kbd>
  * - **"swap":** Convert stylesheet links to preloads that swap to `rel="stylesheet"` once loaded ([details](https://www.filamentgroup.com/lab/load-css-simpler/#the-code)). <kbd>JS</kbd>
  * - **"swap-high":** Use `<link rel="alternate stylesheet preload">` and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-high.html)). <kbd>JS</kbd>
+ * - **"swap-low":** Use `<link rel="alternate stylesheet">` (no `preload` in `rel` here!) and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-low.html)). It ensures lowest priority compare to `swap-high`. <kbd>JS</kbd>
  * - **"js":** Inject an asynchronous CSS loader similar to [LoadCSS](https://github.com/filamentgroup/loadCSS) and use it to load stylesheets. <kbd>JS</kbd>
  * - **"js-lazy":** Like `"js"`, but the stylesheet is disabled until fully loaded.
  * - **false:** Disables adding preload tags.
- * @typedef {(default|'body'|'media'|'swap'|'swap-high'|'js'|'js-lazy')} PreloadStrategy
+ * @typedef {(default|'body'|'media'|'swap'|'swap-high'|'swap-low'|'js'|'js-lazy')} PreloadStrategy
  * @public
  */
 
@@ -379,6 +380,12 @@ export default class Critters {
       } else if (preloadMode === 'swap-high') {
         // @see http://filamentgroup.github.io/loadCSS/test/new-high.html
         link.setAttribute('rel', 'alternate stylesheet preload');
+        link.setAttribute('title', 'styles');
+        link.setAttribute('onload', `this.title='';this.rel='stylesheet'`);
+        noscriptFallback = true;
+      } else if (preloadMode === 'swap-low') {
+        // @see http://filamentgroup.github.io/loadCSS/test/new-low.html
+        link.setAttribute('rel', 'alternate stylesheet');
         link.setAttribute('title', 'styles');
         link.setAttribute('onload', `this.title='';this.rel='stylesheet'`);
         noscriptFallback = true;


### PR DESCRIPTION
`swap-low` uses `rel="alternate stylesheet"` instead of `rel="alternate stylesheet preload"` (used by `swap-high`) to ensure the lowest priority.
See https://filamentgroup.github.io/loadCSS/test/new-low.html