### PR TITLE
fix: unable to locate stylesheet

### DIFF
--- a/packages/critters-webpack-plugin/src/index.js
+++ b/packages/critters-webpack-plugin/src/index.js
@@ -169,7 +169,7 @@ export default class CrittersWebpackPlugin extends Critters {
 
     if (!sheet) {
       try {
-        sheet = await this.readFile(this.compilation, filename);
+        sheet = await this.readFile(filename);
         this.logger.warn(
           `Stylesheet "${relativePath}" not found in assets, but a file was located on disk.${
             this.options.pruneSource

--- a/packages/critters-webpack-plugin/test/__snapshots__/from-disk.test.js.snap
+++ b/packages/critters-webpack-plugin/test/__snapshots__/from-disk.test.js.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Usage with comp.assets and pruneSource should process the first html asset 1`] = `
+"<!DOCTYPE html><html lang=\\"en\\"><head>
+    <title>Loading asset from disk</title>
+    <style>:root {
+  font-size: 10px;
+}
+html, body {
+  width: 100%;
+  height: 100%;
+}
+</style><link rel=\\"preload\\" href=\\"style.css\\" as=\\"style\\">
+  </head>
+  <body>
+    <h1>Some HTML Here</h1>
+  
+
+<link rel=\\"stylesheet\\" href=\\"style.css\\"></body></html>"
+`;
+
+exports[`Usage with comp.assets should process the first html asset 1`] = `
+"<!DOCTYPE html><html lang=\\"en\\"><head>
+    <title>Loading asset from disk</title>
+    <style>:root {
+  font-size: 10px;
+}
+html, body {
+  width: 100%;
+  height: 100%;
+}
+</style><link rel=\\"preload\\" href=\\"style.css\\" as=\\"style\\">
+  </head>
+  <body>
+    <h1>Some HTML Here</h1>
+  
+
+<link rel=\\"stylesheet\\" href=\\"style.css\\"></body></html>"
+`;
+
+exports[`Usage without comp.assets with loading from disk should process the first html asset 1`] = `
+"<!DOCTYPE html><html lang=\\"en\\"><head>
+    <title>Loading asset from disk</title>
+    <style>:root {
+  font-size: 10px;
+}
+html, body {
+  width: 100%;
+  height: 100%;
+}
+</style><link rel=\\"preload\\" href=\\"style.css\\" as=\\"style\\">
+  </head>
+  <body>
+    <h1>Some HTML Here</h1>
+  
+
+<link rel=\\"stylesheet\\" href=\\"style.css\\"></body></html>"
+`;
+
+exports[`webpack compilation 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <title>Loading asset from disk</title>
+    <link rel=\\"stylesheet\\" href=\\"style.css\\">
+  </head>
+  <body>
+    <h1>Some HTML Here</h1>
+  </body>
+</html>
+"
+`;

--- a/packages/critters-webpack-plugin/test/fixtures/fromDisk/index.html
+++ b/packages/critters-webpack-plugin/test/fixtures/fromDisk/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Loading asset from disk</title>
+    <link rel="stylesheet" href="style.css">
+  </head>
+  <body>
+    <h1>Some HTML Here</h1>
+  </body>
+</html>

--- a/packages/critters-webpack-plugin/test/fixtures/fromDisk/index.js
+++ b/packages/critters-webpack-plugin/test/fixtures/fromDisk/index.js
@@ -1,0 +1,4 @@
+import html from './index.html';
+import style from './style.css';
+
+module.exports = {html, style};

--- a/packages/critters-webpack-plugin/test/fixtures/fromDisk/style.css
+++ b/packages/critters-webpack-plugin/test/fixtures/fromDisk/style.css
@@ -1,0 +1,10 @@
+:root {
+  font-size: 10px;
+}
+html, body {
+  width: 100%;
+  height: 100%;
+}
+.excluded-class {
+  background: #fff;
+}

--- a/packages/critters-webpack-plugin/test/from-disk.test.js
+++ b/packages/critters-webpack-plugin/test/from-disk.test.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { compile, compileToHtml, parseDom, readFile } from './_helpers.js';
+
+function configureEmit(config) {
+  config.module.rules.push(
+    {
+      test: /\.html$/,
+      loader: 'file-loader?name=[name].[ext]'
+    },
+    {
+      test: /\.css$/,
+      loader: 'file-loader?name=[name].[ext]&emitFile=true'
+    }
+  );
+}
+
+function configureNoEmit(config) {
+  config.module.rules.push(
+    {
+      test: /\.html$/,
+      loader: 'file-loader?name=[name]-fd.[ext]'
+    },
+    {
+      test: /\.css$/,
+      loader: 'file-loader?name=[name].[ext]&emitFile=false'
+    }
+  );
+}
+
+test('webpack compilation', async () => {
+  const info = await compile('fixtures/fromDisk/index.js', configureEmit);
+  expect(info.assets).toHaveLength(3);
+  const html = await readFile('fixtures/fromDisk/index.html');
+  expect(html).toMatchSnapshot();
+  expect(html).toMatch(/link\srel="stylesheet"\shref=".*?"/);
+});
+
+describe('Usage without comp.assets with loading from disk',() => {
+  let html, document;
+  beforeAll(async () => {
+    await compileToHtml('fromDisk', configureNoEmit);
+    html = await readFile('fixtures/fromDisk/dist/index-fd.html');
+    document = parseDom(html);
+  });
+  it('should process the first html asset',() => {
+    expect(html).toMatchSnapshot();
+    expect(html).toMatch(/link\srel="preload".*?as="style"/);
+    expect(document.querySelectorAll('style')).toHaveLength(1);
+  });
+});
+
+describe('Usage with comp.assets',() => {
+  let output;
+  beforeAll(async () => {
+    output = await compileToHtml('fromDisk', configureEmit);
+  });
+  it('should process the first html asset', () => {
+    const { html, document } = output;
+    expect(html).toMatchSnapshot();
+    expect(html).toMatch(/link\srel="preload".*?as="style"/);
+    expect(document.querySelectorAll('style')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
- extra argument "this.compilation" passed to the readFile function has been removed;
- added a test and resources;
- snapshots generated, tests passed.

Solution for the issue: 
**Issue** https://github.com/GoogleChromeLabs/critters/issues/106