### PR TITLE
Pin `css-select` to latest compatible version

### DIFF
--- a/packages/critters/package.json
+++ b/packages/critters/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "css-select": "^4.2.0",
+    "css-select": "4.2.1",
     "parse5": "^6.0.1",
     "parse5-htmlparser2-tree-adapter": "^6.0.1",
     "postcss": "^8.3.7",

--- a/packages/critters/test/__snapshots__/critters.test.js.snap
+++ b/packages/critters/test/__snapshots__/critters.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Critters \`.foo + *\` selector should not raise warnings 1`] = `"<!DOCTYPE html><html><head></head><body></body></html>"`;
+
 exports[`Critters Basic Usage 1`] = `
 "<html><head>
     <style>h1{color:blue}p{color:purple}</style><link rel=\\"preload\\" href=\\"/style.css\\" as=\\"style\\">

--- a/packages/critters/test/critters.test.js
+++ b/packages/critters/test/critters.test.js
@@ -51,4 +51,34 @@ describe('Critters', () => {
     expect(result).toMatch('<link rel="stylesheet" href="/style.css">');
     expect(result).toMatchSnapshot();
   });
+
+  test('`.foo + *` selector should not raise warnings', async () => {
+    const warnOrError = jest.fn();
+    const noop = () => null;
+
+    const critters = new Critters({
+      logger: {
+        trace: noop,
+        debug: noop,
+        info: noop,
+        warn: warnOrError,
+        error: warnOrError
+      }
+    });
+
+    const result = await critters.process(trim`
+      <!DOCTYPE html>
+      <style>
+        .foo + * {
+        color: red;
+      }
+      </style>
+    `);
+
+    expect(result).toMatchSnapshot();
+    expect(warnOrError.mock.calls).toEqual([
+        ['Merging inline stylesheets into a single <style> tag skipped, no inline stylesheets to merge']
+      ]
+    );
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3369,17 +3369,7 @@ css-select-base-adapter@^0.1.1:
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"
   integrity sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==
 
-css-select@^2.0.0, css-select@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz#6a34653356635934a81baca68d0255432105dbef"
-  integrity sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
-  dependencies:
-    boolbase "^1.0.0"
-    css-what "^3.2.1"
-    domutils "^1.7.0"
-    nth-check "^1.0.2"
-
-css-select@^4.2.0:
+css-select@4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.2.1.tgz#9e665d6ae4c7f9d65dbe69d0316e3221fb274cdd"
   integrity sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==
@@ -3389,6 +3379,16 @@ css-select@^4.2.0:
     domhandler "^4.3.0"
     domutils "^2.8.0"
     nth-check "^2.0.1"
+
+css-select@^2.0.0, css-select@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz#6a34653356635934a81baca68d0255432105dbef"
+  integrity sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^3.2.1"
+    domutils "^1.7.0"
+    nth-check "^1.0.2"
 
 css-selector-tokenizer@^0.7.0:
   version "0.7.3"
@@ -3840,9 +3840,9 @@ domhandler@^4.2.0:
     domelementtype "^2.2.0"
 
 domhandler@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.0.tgz#16c658c626cf966967e306f966b431f77d4a5626"
-  integrity sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
+  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
 


### PR DESCRIPTION
The proper long-term solution is discussed in
https://github.com/GoogleChromeLabs/critters/issues/103#issuecomment-1208236366 but until then we should at least not break existing install that upgrade their dependencies.

Without this we would get errors similar to:

```
rules skipped due to selector errors
```

Fixes #103