### PR TITLE
fix: CJS distributable consumption

### DIFF
--- a/packages/critters/package.json
+++ b/packages/critters/package.json
@@ -46,13 +46,13 @@
     "prepare": "npm run -s build"
   },
   "dependencies": {
-    "chalk": "^5.2.0",
+    "chalk": "^4.1.0",
     "css-select": "^5.1.0",
     "dom-serializer": "^2.0.0",
     "domhandler": "^5.0.2",
     "htmlparser2": "^8.0.2",
     "postcss": "^8.4.23",
-    "pretty-bytes": "^6.1.0"
+    "pretty-bytes": "^5.3.0"
   },
   "devDependencies": {
     "documentation": "^13.0.2",


### PR DESCRIPTION
The used versions of `chalk` and `pretty-bytes` are ESM packages which breaks CJS consumption as they are not loaded using ESM dynamic imports.

Example of error
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /node_modules/critters/node_modules/chalk/source/index.js from /node_modules/critters/dist/critters.js not supported.
```

This commit downgrades these packages to their CJS versions.