### PR TITLE
fix: fixes issue where `:not()` contains multiple removed params

### DIFF
--- a/packages/critters/src/index.js
+++ b/packages/critters/src/index.js
@@ -547,7 +547,15 @@ export default class Critters {
             }
             sel = sel
               .replace(/(?<!\\)::?[a-z-]+(?![a-z-(])/gi, '')
-              .replace(/::?not\(\s*\)/g, '')
+              .replace(/(::?not)\(([^)]*)\)/g, (_, p1, p2) => {
+                const params = (p2 || '')
+                  .split(',')
+                  .map((item) => item.trim())
+                  .filter(Boolean)
+                  .join(',');
+
+                return Boolean(params) ? `${p1}(${params})` : '';
+              })
               .trim();
             if (!sel) return false;
 


### PR DESCRIPTION
#### What does this PR do

* Fixes an issue where CSS selectors with `:not` pseudo-elements such as `:not(:active,:hover,.myClass)` would result in a `:not(,,.myClass)` after the extraction of pseudo sub-selectors.

By adding a replacement function, the arguments are extracted and split by `,`, then combined back.

It is my first PR to this project, so pretty please give me feedback so that I can improve it as much as possible 👍 Thanks in advance.

Relates to #102 