### PR TITLE
fix: handle sub-selector with both classes and pseudo selectors

### DIFF
--- a/packages/critters/src/index.js
+++ b/packages/critters/src/index.js
@@ -548,6 +548,9 @@ export default class Critters {
             sel = sel
               .replace(/(?<!\\)::?[a-z-]+(?![a-z-(])/gi, '')
               .replace(/::?not\(\s*\)/g, '')
+               // Remove tailing or leading commas from cleaned sub selector `is(.active, :hover)` -> `is(.active)`.
+              .replace(/\(\s*,/g, '(')
+              .replace(/,\s*\)/g, ')')
               .trim();
             if (!sel) return false;
 

--- a/packages/critters/test/__snapshots__/critters.test.js.snap
+++ b/packages/critters/test/__snapshots__/critters.test.js.snap
@@ -17,7 +17,7 @@ exports[`Critters Run on HTML file 1`] = `
   <head>
     <title>Testing</title>
     <style>h1{color:blue}p{color:purple}.contents{padding:50px;text-align:center}.input-field{padding:10px}.custom-element::part(tab){color:#0c0dcc;border-bottom:transparent solid 2px}.custom-element::part(tab):hover:active{background-color:#0c0d33;color:#ffffff}.custom-element::part(tab):focus{box-shadow:0 0 0 1px #0a84ff inset, 0 0 0 1px #0a84ff,
-    0 0 0 4px rgba(10, 132, 255, 0.3)}</style><link rel=\\"preload\\" href=\\"styles.css\\" as=\\"style\\">
+    0 0 0 4px rgba(10, 132, 255, 0.3)}div:is(:hover, .active){color:#000}div:is(.selected, :hover){color:#fff}</style><link rel=\\"preload\\" href=\\"styles.css\\" as=\\"style\\">
   </head>
   <body>
     <div class=\\"container\\">
@@ -30,6 +30,7 @@ exports[`Critters Run on HTML file 1`] = `
       <p>This is a paragraph</p>
       <input class=\\"input-field\\">
       <div class=\\"contents\\"></div>
+      <div class=\\"selected active\\"></div>
     </div>
     <footer class></footer>
   <link rel=\\"stylesheet\\" href=\\"styles.css\\"></body>

--- a/packages/critters/test/src/index.html
+++ b/packages/critters/test/src/index.html
@@ -14,6 +14,7 @@
       <p>This is a paragraph</p>
       <input class="input-field" />
       <div class="contents"></div>
+      <div class="selected active"></div>
     </div>
     <footer class=""></footer>
   </body>

--- a/packages/critters/test/src/styles.css
+++ b/packages/critters/test/src/styles.css
@@ -69,3 +69,11 @@ footer {
   color: #0060df;
   border-color: #0a84ff !important;
 }
+
+div:is(:hover, .active) {
+  color: #000;
+}
+
+div:is(.selected, :hover) {
+  color: #fff;
+}


### PR DESCRIPTION
Prior to this change sub-selectors where incorrectly processed.

Example `div:is(:hover, .active)` would be turned into `div:is(, .active)` which caused the parser to emit an `Empty sub-selector` error.

//cc @janicklas-ralph 