### PR TITLE
fix: do not encode special characters

### DIFF
--- a/packages/critters/src/dom.js
+++ b/packages/critters/src/dom.js
@@ -79,7 +79,7 @@ export function createDocument(html) {
  * @param {HTMLDocument} document   A Document, such as one created via `createDocument()`
  */
 export function serializeDocument(document) {
-  return render(document);
+  return render(document, { decodeEntities: false });
 }
 
 /** @typedef {treeAdapter.Document & typeof ElementExtensions} HTMLDocument */

--- a/packages/critters/test/critters.test.js
+++ b/packages/critters/test/critters.test.js
@@ -68,4 +68,31 @@ describe('Critters', () => {
     const result = await critters.process(html);
     expect(result).toMatchSnapshot();
   });
+
+  test('Does not encode HTML', async () => {
+    const critters = new Critters({
+      reduceInlineStyles: false,
+      path: '/'
+    });
+    const assets = {
+      '/style.css': trim`
+        h1 { color: blue; }
+      `
+    };
+    critters.readFile = (filename) => assets[filename];
+    const result = await critters.process(trim`
+      <html>
+        <head>
+          <title>$title</title>
+          <link rel="stylesheet" href="/style.css">
+        </head>
+        <body>
+          <h1>Hello World!</h1>
+        </body>
+      </html>
+    `);
+    expect(result).toMatch('<style>h1{color:blue}</style>');
+    expect(result).toMatch('<link rel="stylesheet" href="/style.css">');
+    expect(result).toMatch('<title>$title</title>');
+  });
 });


### PR DESCRIPTION
The latest version of critters introduced a breaking behaviour which causes special characters to be encoded.

This commit removes this behaviour and restores the previous one.

See: https://github.com/angular/angular-cli/issues/25388