### PR TITLE
fix: properly removes all empty sub-selectors based on pseudo-elements

### DIFF
--- a/packages/critters/src/index.js
+++ b/packages/critters/src/index.js
@@ -547,10 +547,16 @@ export default class Critters {
             }
             sel = sel
               .replace(/(?<!\\)::?[a-z-]+(?![a-z-(])/gi, '')
-              .replace(/::?not\(\s*\)/g, '')
-               // Remove tailing or leading commas from cleaned sub selector `is(.active, :hover)` -> `is(.active)`.
-              .replace(/\(\s*,/g, '(')
-              .replace(/,\s*\)/g, ')')
+              // Remove tailing or leading commas from cleaned sub selector `is(.active, :hover)` -> `is(.active)`.
+              .replace(/(::?[a-z0-9-]+)\(([^)]*)\)/gi, (_, p1, p2) => {
+                const params = (p2 || '')
+                  .split(',')
+                  .map((item) => item.trim())
+                  .filter(Boolean)
+                  .join(',');
+
+                return params ? `${p1}(${params})` : '';
+              })
               .trim();
             if (!sel) return false;
 

--- a/packages/critters/test/__snapshots__/critters.test.js.snap
+++ b/packages/critters/test/__snapshots__/critters.test.js.snap
@@ -17,7 +17,7 @@ exports[`Critters Run on HTML file 1`] = `
   <head>
     <title>Testing</title>
     <style>h1{color:blue}p{color:purple}.contents{padding:50px;text-align:center}.input-field{padding:10px}.custom-element::part(tab){color:#0c0dcc;border-bottom:transparent solid 2px}.custom-element::part(tab):hover:active{background-color:#0c0d33;color:#ffffff}.custom-element::part(tab):focus{box-shadow:0 0 0 1px #0a84ff inset, 0 0 0 1px #0a84ff,
-    0 0 0 4px rgba(10, 132, 255, 0.3)}div:is(:hover, .active){color:#000}div:is(.selected, :hover){color:#fff}</style><link rel=\\"preload\\" href=\\"styles.css\\" as=\\"style\\">
+    0 0 0 4px rgba(10, 132, 255, 0.3)}div:is(:hover, .active){color:#000}div:is(.selected, :hover){color:#fff}div:not(:focus, .contents, :hover, .input-field){color:#fff}</style><link rel=\\"preload\\" href=\\"styles.css\\" as=\\"style\\">
   </head>
   <body>
     <div class=\\"container\\">

--- a/packages/critters/test/src/styles.css
+++ b/packages/critters/test/src/styles.css
@@ -64,7 +64,6 @@ footer {
 }
 /* critters:include end */
 
-
 .custom-element::part(active) {
   color: #0060df;
   border-color: #0a84ff !important;
@@ -75,5 +74,13 @@ div:is(:hover, .active) {
 }
 
 div:is(.selected, :hover) {
+  color: #fff;
+}
+
+div:is(:focus-within, :hover, .input-field) {
+  color: #fff;
+}
+
+div:not(:focus, .contents, :hover, .input-field) {
   color: #fff;
 }


### PR DESCRIPTION
#### What does this PR do

Previously on PR #129, a fix was introduced to fix the cases where a sub-selector is "empty" after the replacements.
While the fix works for cases mentioned in the commit:

> Example `div:is(:hover, .active)` would be turned into `div:is(, .active)` which caused the parser to emit an `Empty sub-selector` error.

It does not work if you have multiple cases, example:

`.Input_input__c1Di2:hover:not(:focus,:focus-within,:disabled,.Input_input--error__JQLeU)`, becomes `.Input_input__c1Di2:not(,,.Input_input--error__JQLeU)` (only the first "empty" case is removed)

In fact, if we have in between cases - e.g. `.Input_input__c1Di2:hover:not(:focus,.class1, :focus-within,.class2,:disabled,.Input_input--error__JQLeU)` adding the repetition to the RegExp still won't work, because it'll only clear the ones in the edges.

This PR attempts to fix this by extracting all params within parenthesis and extract the sub-selectors.