### PR TITLE
fix: prevent document parsing from decoding entities within HTML document

### DIFF
--- a/packages/critters/src/dom.js
+++ b/packages/critters/src/dom.js
@@ -53,7 +53,7 @@ function buildCache(container) {
  * @param {String} html   HTML to parse into a Document instance
  */
 export function createDocument(html) {
-  const document = /** @type {HTMLDocument} */ (parseDocument(html));
+  const document = /** @type {HTMLDocument} */ (parseDocument(html, {decodeEntities: false}));
 
   defineProperties(document, DocumentExtensions);
 

--- a/packages/critters/test/critters.test.js
+++ b/packages/critters/test/critters.test.js
@@ -95,4 +95,19 @@ describe('Critters', () => {
     expect(result).toMatch('<link rel="stylesheet" href="/style.css">');
     expect(result).toMatch('<title>$title</title>');
   });
+
+  test('Does not decode entities in HTML document', async () => {
+    const critters = new Critters({
+      path: '/'
+    });
+    critters.readFile = (filename) => assets[filename];
+    const result = await critters.process(trim`
+      <html>
+        <body>
+          &lt;h1&gt;Hello World!&lt;/h1&gt;
+        </body>
+      </html>
+    `);
+    expect(result).toMatch('&lt;h1&gt;Hello World!&lt;/h1&gt;');
+  });
 });


### PR DESCRIPTION
Decoding the entities within HTML content can lead to undoing escapes