### PR TITLE
fix: export the ts types when using moduleResolution "bundler"/"node16"

### DIFF
--- a/packages/critters/package.json
+++ b/packages/critters/package.json
@@ -6,6 +6,7 @@
   "module": "dist/critters.mjs",
   "source": "src/index.js",
   "exports": {
+    "types": "./src/index.d.ts",
     "import": "./dist/critters.mjs",
     "require": "./dist/critters.js",
     "default": "./dist/critters.mjs"


### PR DESCRIPTION
Would be great if this could be merged along with #101