### PR TITLE
fix: bundling with Angular CLI and Webpack

### DIFF
--- a/packages/critters/src/css.js
+++ b/packages/critters/src/css.js
@@ -239,7 +239,9 @@ function validateMediaType(node) {
  * is HTML safe and does not cause any injection issue
  */
 export function validateMediaQuery(query) {
-  const mediaTree = mediaParser(query);
+  // The below is needed for consumption with webpack.
+  const mediaParserFn = 'default' in mediaParser ? mediaParser.default : mediaParser;
+  const mediaTree = mediaParserFn(query);
   const nodeTypes = new Set(['media-type', 'keyword', 'media-feature']);
 
   const stack = [mediaTree];


### PR DESCRIPTION
`postcss-media-query-parser` is a CommonJS (CJS) module, and its default export differs from the ECMAScript Module (ESM) format. This variance causes `critters` to encounter issues when bundled with webpack.