### PR TITLE
fix: retain all attributes from the original link tag

### DIFF
--- a/packages/critters-webpack-plugin/test/__snapshots__/index.test.js.snap
+++ b/packages/critters-webpack-plugin/test/__snapshots__/index.test.js.snap
@@ -66,7 +66,7 @@ footer {
     <h1>My first styled page</h1>
     <p>Welcome to my styled page!</p>
     <footer>Made 5 April 2004</footer>
-  <script src=\\"bundle.js\\"></script><link rel=\\"stylesheet\\" href=\\"main.css\\"></body>
+  <script src=\\"bundle.js\\"></script><link href=\\"main.css\\" rel=\\"stylesheet\\"></body>
 </html>
 "
 `;
@@ -195,7 +195,7 @@ html {
     <h1 class=\\"additional-style\\">My first styled page</h1>
     <p>Welcome to my styled page!</p>
     <footer>Made 5 April 2004</footer>
-  <script src=\\"bundle.js\\"></script><link rel=\\"stylesheet\\" href=\\"main.css\\"></body>
+  <script src=\\"bundle.js\\"></script><link href=\\"main.css\\" rel=\\"stylesheet\\"></body>
 </html>
 "
 `;
@@ -266,7 +266,7 @@ footer {
     <h1>My first styled page</h1>
     <p>Welcome to my styled page!</p>
     <footer>Made 5 April 2004</footer>
-  <script src=\\"bundle.js\\"></script><link rel=\\"stylesheet\\" href=\\"main.css\\"></body>
+  <script src=\\"bundle.js\\"></script><link href=\\"main.css\\" rel=\\"stylesheet\\"></body>
 </html>
 "
 `;
@@ -337,7 +337,7 @@ footer {
     <h1>My first styled page</h1>
     <p>Welcome to my styled page!</p>
     <footer>Made 5 April 2004</footer>
-  <script src=\\"/_public/bundle.js\\"></script><link rel=\\"stylesheet\\" href=\\"/_public/main.css\\"></body>
+  <script src=\\"/_public/bundle.js\\"></script><link href=\\"/_public/main.css\\" rel=\\"stylesheet\\"></body>
 </html>
 "
 `;

--- a/packages/critters/test/__snapshots__/critters.test.js.snap
+++ b/packages/critters/test/__snapshots__/critters.test.js.snap
@@ -17,8 +17,8 @@ exports[`Critters Prevent injection via media attr 1`] = `
   <link>
     <title>Testing</title>
     <style>h1{color:blue}p{color:purple}.contents{padding:50px;text-align:center}.input-field{padding:10px}.custom-element::part(tab){color:#0c0dcc;border-bottom:transparent solid 2px}.custom-element::part(tab):hover:active{background-color:#0c0d33;color:#ffffff}.custom-element::part(tab):focus{box-shadow:0 0 0 1px #0a84ff inset, 0 0 0 1px #0a84ff,
-    0 0 0 4px rgba(10, 132, 255, 0.3)}div:is(:hover, .active){color:#000}div:is(.selected, :hover){color:#fff}body{height:100%}</style><link rel=\\"stylesheet\\" href=\\"styles.css\\" media=\\"print\\" onload=\\"this.media='all'\\"><noscript><link rel=\\"stylesheet\\" href=\\"styles.css\\"></noscript>
-    <link rel=\\"stylesheet\\" href=\\"styles2.css\\" media=\\"print\\" onload=\\"this.media='screen and (min-width: 480px)'\\"><noscript><link rel=\\"stylesheet\\" href=\\"styles2.css\\" media=\\"screen and (min-width: 480px)\\"></noscript>
+    0 0 0 4px rgba(10, 132, 255, 0.3)}div:is(:hover, .active){color:#000}div:is(.selected, :hover){color:#fff}body{height:100%}</style><link rel=\\"stylesheet\\" href=\\"styles.css\\" media=\\"print\\" onload=\\"this.media='all'\\"><noscript><link rel=\\"stylesheet\\" href=\\"styles.css\\" media=\\"print\\" onload=\\"this.media='all'\\"></noscript>
+    <link rel=\\"stylesheet\\" href=\\"styles2.css\\" media=\\"print\\" onload=\\"this.media='screen and (min-width: 480px)'\\"><noscript><link rel=\\"stylesheet\\" href=\\"styles2.css\\" media=\\"print\\" onload=\\"this.media='screen and (min-width: 480px)'\\"></noscript>
   
   <body>
     <div class=\\"container\\">
@@ -90,4 +90,28 @@ exports[`Critters Skip invalid path 1`] = `
   <link rel=\\"stylesheet\\" href=\\"styles.css\\"></body>
 </html>
 "
+`;
+
+exports[`Critters should keep existing link tag attributes 1`] = `
+"<html data-critters-container>
+  <head>
+    <title>$title</title>
+    <style>h1{color:blue}</style><link rel=\\"preload\\" href=\\"/style.css\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-j1GsrLo96tLqzfCY+\\" as=\\"style\\">
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+  <link rel=\\"stylesheet\\" href=\\"/style.css\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-j1GsrLo96tLqzfCY+\\"></body>
+</html>"
+`;
+
+exports[`Critters should keep existing link tag attributes in the noscript link 1`] = `
+"<html data-critters-container>
+  <head>
+    <title>$title</title>
+    <style>h1{color:blue}</style><link rel=\\"stylesheet\\" href=\\"/style.css\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-j1GsrLo96tLqzfCY+\\" media=\\"print\\" onload=\\"this.media='all'\\"><noscript><link rel=\\"stylesheet\\" href=\\"/style.css\\" crossorigin=\\"anonymous\\" integrity=\\"sha384-j1GsrLo96tLqzfCY+\\" media=\\"print\\" onload=\\"this.media='all'\\"></noscript>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+  </body>
+</html>"
 `;

--- a/packages/critters/test/critters.test.js
+++ b/packages/critters/test/critters.test.js
@@ -96,6 +96,67 @@ describe('Critters', () => {
     expect(result).toMatch('<title>$title</title>');
   });
 
+  test('should keep existing link tag attributes in the noscript link', async () => {
+    const critters = new Critters({
+      reduceInlineStyles: false,
+      path: '/',
+      preload: 'media'
+    });
+    const assets = {
+      '/style.css': trim`
+        h1 { color: blue; }
+      `
+    };
+    critters.readFile = (filename) => assets[filename];
+    const result = await critters.process(trim`
+      <html>
+        <head>
+          <title>$title</title>
+          <link rel="stylesheet" href="/style.css" crossorigin="anonymous" integrity="sha384-j1GsrLo96tLqzfCY+">
+        </head>
+        <body>
+          <h1>Hello World!</h1>
+        </body>
+      </html>
+    `);
+
+    expect(result).toMatch('<style>h1{color:blue}</style>');
+    expect(result).toMatch(
+      `<link rel="stylesheet" href="/style.css" crossorigin="anonymous" integrity="sha384-j1GsrLo96tLqzfCY+" media="print" onload="this.media='all'">`
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  test('should keep existing link tag attributes', async () => {
+    const critters = new Critters({
+      reduceInlineStyles: false,
+      path: '/',
+    });
+    const assets = {
+      '/style.css': trim`
+        h1 { color: blue; }
+      `
+    };
+    critters.readFile = (filename) => assets[filename];
+    const result = await critters.process(trim`
+      <html>
+        <head>
+          <title>$title</title>
+          <link rel="stylesheet" href="/style.css" crossorigin="anonymous" integrity="sha384-j1GsrLo96tLqzfCY+">
+        </head>
+        <body>
+          <h1>Hello World!</h1>
+        </body>
+      </html>
+    `);
+
+    expect(result).toMatch('<style>h1{color:blue}</style>');
+    expect(result).toMatch(
+      `<link rel="stylesheet" href="/style.css" crossorigin="anonymous" integrity="sha384-j1GsrLo96tLqzfCY+">`
+    );
+    expect(result).toMatchSnapshot();
+  });
+
   test('Does not decode entities in HTML document', async () => {
     const critters = new Critters({
       path: '/'


### PR DESCRIPTION
Before this commit, the generated link tags were missing some attributes, which caused issues when attributes like `integrity`, `nonce`, and `crossorigin` were not applied.

See https://github.com/angular/angular-cli/issues/27881 for more context.