### PR TITLE
Optimizing Performance by Caching Critical CSS

### DIFF
--- a/packages/critters/package.json
+++ b/packages/critters/package.json
@@ -51,6 +51,7 @@
     "dom-serializer": "^2.0.0",
     "domhandler": "^5.0.2",
     "htmlparser2": "^8.0.2",
+    "node-cache": "^5.1.2",
     "postcss": "^8.4.23",
     "postcss-media-query-parser": "^0.2.3"
   },

--- a/packages/critters/src/dom.js
+++ b/packages/critters/src/dom.js
@@ -31,15 +31,15 @@ function buildCache(container) {
   while (queue.length) {
     const node = queue.shift();
 
-    if (node.hasAttribute('class')) {
-      const classList = node.getAttribute('class').trim().split(' ');
+    if (node.attribs['class']) {
+      const classList = node.attribs['class'].trim().split(' ');
       classList.forEach((cls) => {
         classCache.add(cls);
       });
     }
 
-    if (node.hasAttribute('id')) {
-      const id = node.getAttribute('id').trim();
+    if (node.attribs['id']) {
+      const id = node.attribs['id'].trim();
       idCache.add(id);
     }
 
@@ -64,7 +64,7 @@ export function createDocument(html) {
   let crittersContainer = document.querySelector('[data-critters-container]');
 
   if (!crittersContainer) {
-    document.documentElement.setAttribute('data-critters-container', '');
+    document.documentElement.attribs['data-critters-container'] = '';
     crittersContainer = document.documentElement;
   }
 


### PR DESCRIPTION
Caching CSS Based on a Data-Attribute (e.g., **data-pagetype**)

To enable this feature, first pass a key in the options: **`cacheCriticalCSS: true`**.

Next, add a class named **page_layout_nxt** to any **`<div>`** in the HTML and provide a data attribute (e.g., **data-pagetype**). This data attribute can be any unique key based on a combination of page name, user logged in status, and device type (mobile/desktop).


Critical CSS is then saved in the cache and returned from the cache instead of being recalculated for the same unique key. This will improve the Time to First Byte (TTFB).

### Related Issue:

This pull request closes #169